### PR TITLE
Works for all interfaces now, not just en1. 

### DIFF
--- a/talkserver.rb
+++ b/talkserver.rb
@@ -2,8 +2,7 @@
 
 require 'socket'
 
-ip_addr = `ifconfig en1`.match(/inet (\d*\.\d*\.\d*\.\d*)/)[1]
-
+ip_addr = IPSocket.getaddress(Socket.gethostname)
 
 server = TCPServer.new(ip_addr, 8000)
 


### PR DESCRIPTION
I couldn't get this to work because I was connected on en0. Change this line and it'll work for all interfaces. Thanks!